### PR TITLE
make images arg optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,13 @@ var _ = require('lodash');
 var insertCSS = require('insert-css');
 var inherits = require('inherits');
 var qwery = require('qwery');
+var isarray = require('isarray')
 
 var LightningVisualization = function(selector, data, images, options) {
+    if (!options && !isarray(images) && typeof images === 'object') {
+        options = images
+        images = null
+    }
 
     this.options = _.defaults(options || {}, this.getDefaultOptions());
     this.styles = this.getDefaultStyles();

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "inherits": "^2.0.1",
     "insert-css": "^0.2.0",
+    "isarray": "^1.0.0",
     "lodash": "^3.9.3",
     "qwery": "^4.0.0"
   },


### PR DESCRIPTION
This is a small update to make the images argument optional. In examples so far I've been leaving it as `null`, but since many of the viz types don't deal with images, this will make usage a little simpler.
